### PR TITLE
Add codec in video metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Returns:
 | -------------------------- | ------- | ------------------------------------------------------ |
 | `width`                    | number  | Width of the primary video stream                      |
 | `height`                   | number  | Height of the primary video stream                     |
+| `codec.id`                 | number  | FFmpeg codec id of the primary video stream            |
+| `codec.name`               | string  | FFmpeg codec name of the primary video stream          |
 | `duration`                 | number  | Stream duration in seconds                             |
 | `avgFramerate.numerator`   | number  | Average frame rate numerator                           |
 | `avgFramerate.denominator` | number  | Average frame rate denominator                         |

--- a/src/video/index.js
+++ b/src/video/index.js
@@ -122,15 +122,15 @@ async function metadata(fd) {
   correctiveRotation = ((-displayRotation % 360) + 360) % 360
 
   const codec = stream.codec
+  const { codec, codecParameters } = stream
 
-  const duration =
-    Number.isFinite(stream.duration) && stream.timeBase.denominator !== 0
-      ? (stream.duration * stream.timeBase.numerator) / stream.timeBase.denominator
-      : stream.duration
-
-  return {
-    width: stream.codecParameters.width,
-    height: stream.codecParameters.height,
+const duration =
+Number.isFinite(stream.duration) && stream.timeBase.denominator !== 0
+? (stream.duration * stream.timeBase.numerator) / stream.timeBase.denominator
+@@ -129,6 +131,10 @@ async function metadata(fd) {
+return {
+width: codecParameters.width,
+height: codecParameters.height,
     codec: {
       id: codec.id,
       name: codec.name

--- a/src/video/index.js
+++ b/src/video/index.js
@@ -215,9 +215,15 @@ async function getFormatRegistry() {
   return formatRegistry
 }
 
+async function getConstants() {
+  const ffmpeg = await import('bare-ffmpeg')
+  return ffmpeg.constants
+}
+
 video.extractFrames = extractFrames
 video.metadata = metadata
 video.transcode = transcode
 video.getFormatRegistry = getFormatRegistry
+video.getConstants = getConstants
 
 export { video }

--- a/src/video/index.js
+++ b/src/video/index.js
@@ -121,6 +121,8 @@ async function metadata(fd) {
 
   correctiveRotation = ((-displayRotation % 360) + 360) % 360
 
+  const codec = stream.codec
+
   const duration =
     Number.isFinite(stream.duration) && stream.timeBase.denominator !== 0
       ? (stream.duration * stream.timeBase.numerator) / stream.timeBase.denominator
@@ -129,6 +131,10 @@ async function metadata(fd) {
   return {
     width: stream.codecParameters.width,
     height: stream.codecParameters.height,
+    codec: {
+      id: codec.id,
+      name: codec.name
+    },
     duration,
     avgFramerate: {
       numerator: stream.avgFramerate.numerator,

--- a/src/video/index.js
+++ b/src/video/index.js
@@ -121,7 +121,7 @@ async function metadata(fd) {
 
   correctiveRotation = ((-displayRotation % 360) + 360) % 360
 
-  const codec = stream.codec
+  const { codec, codecParameters } = stream
 
   const duration =
     Number.isFinite(stream.duration) && stream.timeBase.denominator !== 0
@@ -129,8 +129,8 @@ async function metadata(fd) {
       : stream.duration
 
   return {
-    width: stream.codecParameters.width,
-    height: stream.codecParameters.height,
+    width: codecParameters.width,
+    height: codecParameters.height,
     codec: {
       id: codec.id,
       name: codec.name

--- a/src/video/index.js
+++ b/src/video/index.js
@@ -122,15 +122,15 @@ async function metadata(fd) {
   correctiveRotation = ((-displayRotation % 360) + 360) % 360
 
   const codec = stream.codec
-  const { codec, codecParameters } = stream
 
-const duration =
-Number.isFinite(stream.duration) && stream.timeBase.denominator !== 0
-? (stream.duration * stream.timeBase.numerator) / stream.timeBase.denominator
-@@ -129,6 +131,10 @@ async function metadata(fd) {
-return {
-width: codecParameters.width,
-height: codecParameters.height,
+  const duration =
+    Number.isFinite(stream.duration) && stream.timeBase.denominator !== 0
+      ? (stream.duration * stream.timeBase.numerator) / stream.timeBase.denominator
+      : stream.duration
+
+  return {
+    width: stream.codecParameters.width,
+    height: stream.codecParameters.height,
     codec: {
       id: codec.id,
       name: codec.name

--- a/test/video.js
+++ b/test/video.js
@@ -1,7 +1,6 @@
 import { test } from 'brittle'
 import fs from 'bare-fs'
 import b4a from 'b4a'
-import ffmpeg from 'bare-ffmpeg'
 
 import { video } from '..'
 import { parseDisplayMatrix } from '../src/video/display-matrix.js'
@@ -36,11 +35,13 @@ test('video metadata()', async (t) => {
   const metadata = await video.metadata(fd)
   fs.closeSync(fd)
 
+  const constants = await video.getConstants()
+
   t.alike(metadata, {
     width: 120,
     height: 160,
     codec: {
-      id: ffmpeg.constants.codecs.H264,
+      id: constants.codecs.H264,
       name: 'h264'
     },
     duration: 10,
@@ -59,10 +60,11 @@ test('video metadata() in pipeline', async (t) => {
   const path = './test/fixtures/orientation.mov'
 
   const metadata = await video(path).metadata()
+  const constants = await video.getConstants()
 
   t.is(metadata.width, 120)
   t.is(metadata.height, 160)
-  t.is(metadata.codec.id, ffmpeg.constants.codecs.H264)
+  t.is(metadata.codec.id, constants.codecs.H264)
   t.is(metadata.codec.name, 'h264')
   t.is(metadata.duration, 10)
   t.is(metadata.displayRotation, 270)
@@ -356,16 +358,17 @@ test('video.getFormatRegistry() - getAudioConfig throws for unsupported format',
 
 test('video.getFormatRegistry() - register custom format', async (t) => {
   const registry = await video.getFormatRegistry()
+  const constants = await video.getConstants()
 
   registry.register('mp4-ios', {
     video: {
-      id: ffmpeg.constants.codecs.H264,
-      format: ffmpeg.constants.pixelFormats.YUV420P,
+      id: constants.codecs.H264,
+      format: constants.pixelFormats.YUV420P,
       encoder: 'h264_videotoolbox'
     },
     audio: {
-      id: ffmpeg.constants.codecs.AAC,
-      format: ffmpeg.constants.sampleFormats.FLTP,
+      id: constants.codecs.AAC,
+      format: constants.sampleFormats.FLTP,
       sampleRate: 48000,
       encoder: 'aac'
     },

--- a/test/video.js
+++ b/test/video.js
@@ -1,6 +1,7 @@
 import { test } from 'brittle'
 import fs from 'bare-fs'
 import b4a from 'b4a'
+import ffmpeg from 'bare-ffmpeg'
 
 import { video } from '..'
 import { parseDisplayMatrix } from '../src/video/display-matrix.js'
@@ -38,6 +39,10 @@ test('video metadata()', async (t) => {
   t.alike(metadata, {
     width: 120,
     height: 160,
+    codec: {
+      id: ffmpeg.constants.codecs.H264,
+      name: 'h264'
+    },
     duration: 10,
     avgFramerate: {
       numerator: 1,
@@ -54,8 +59,11 @@ test('video metadata() in pipeline', async (t) => {
   const path = './test/fixtures/orientation.mov'
 
   const metadata = await video(path).metadata()
+
   t.is(metadata.width, 120)
   t.is(metadata.height, 160)
+  t.is(metadata.codec.id, ffmpeg.constants.codecs.H264)
+  t.is(metadata.codec.name, 'h264')
   t.is(metadata.duration, 10)
   t.is(metadata.displayRotation, 270)
   t.is(metadata.rotation, 90)
@@ -68,6 +76,7 @@ test('video metadata() defaults', async (t) => {
 
   const metadata = await video(path).metadata()
 
+  t.is(metadata.codec.name, 'h264')
   t.is(metadata.displayRotation, 0)
   t.is(metadata.rotation, 0)
   t.is(metadata.flipH, false)
@@ -346,7 +355,6 @@ test('video.getFormatRegistry() - getAudioConfig throws for unsupported format',
 })
 
 test('video.getFormatRegistry() - register custom format', async (t) => {
-  const ffmpeg = (await import('bare-ffmpeg')).default
   const registry = await video.getFormatRegistry()
 
   registry.register('mp4-ios', {


### PR DESCRIPTION
The id and name of the codec is returned in metadata:
```js
const metadata = await video(path).metadata()
// { codec: { id, name }, ... }
```

To compare the id, ffmpeg constants have been exposed via `getConstants`:
```js
const constants = await video.getConstants()
// constants.codecs.H264 === metadata.codec.id
```