### PR TITLE
Add CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,22 @@ for await (const chunk of video('input.mkv').transcode({
 }
 ```
 
+## CLI
+
+`bare-media [flags] [command]`
+
+```sh
+Flags:
+  --version|-v   Print version
+  --help|-h      Show help
+
+Commands:
+  metadata       Print image or video metadata (experimental)
+  convert        Convert an image
+  transcode      Transcode a video
+  types          List supported MIME types
+```
+
 ## Supported Types
 
 Helpers to check supported media types are exposed in `bare-media/types`:

--- a/bin.js
+++ b/bin.js
@@ -10,6 +10,7 @@ import {
   isStripMetadataSupported
 } from 'bare-media/types'
 import getMimeType from 'get-mime-type'
+import { detectMimeType } from './src/util'
 
 import pkg from './package'
 
@@ -64,18 +65,16 @@ const cli = command(
 
 async function metadata(parsed) {
   const input = validateInput(parsed.args.input)
-  const mimetype = getMimeType(input)
+  const mimetype = detectMimeType(await head(input))
 
   if (parsed.flags.strip) {
+    if (!isStripMetadataSupported(mimetype)) {
+      throw new Error(`Metadata stripping is not supported for ${mimetype}`)
+    }
     if (!parsed.args.output) {
       throw new Error('Missing output path')
     }
     const output = path.resolve(parsed.args.output)
-    const mimetype = getMimeType(input)
-    if (!isStripMetadataSupported(mimetype)) {
-      throw new Error(`Metadata stripping is not supported for ${mimetype}`)
-    }
-
     await image(input).metadata.strip().save(output)
     return
   }
@@ -139,6 +138,20 @@ function types() {
   for (const mimetype of supportedImageMimetypes) console.log(`  ${mimetype}`)
   console.log('Videos:')
   for (const mimetype of supportedVideoMimetypes) console.log(`  ${mimetype}`)
+}
+
+async function head(filePath, byteLength = 4100) {
+  const fd = await fs.open(filePath)
+
+  const buffer = Buffer.alloc(byteLength)
+
+  try {
+    await fs.read(fd, buffer)
+  } finally {
+    await fs.close(fd)
+  }
+
+  return buffer
 }
 
 function validateInput(input) {

--- a/bin.js
+++ b/bin.js
@@ -108,13 +108,22 @@ async function convert(parsed) {
   const mimetype = getMimeType(output)
 
   let pipeline = image(input).decode({ maxFrames })
-  if (parsed.flags.orientate) pipeline = pipeline.orientate()
-  if (maxWidth || maxHeight) {
-    pipeline = pipeline.resize({
-      maxWidth: maxWidth || Number.MAX_SAFE_INTEGER,
-      maxHeight: maxHeight || Number.MAX_SAFE_INTEGER
-    })
+
+  if (parsed.flags.orientate) {
+    pipeline = pipeline.orientate()
   }
+
+  if (maxWidth || maxHeight) {
+    const resizeOpts = {}
+    if (maxWidth) {
+      resizeOpts.maxWidth = maxWidth
+    }
+    if (maxHeight) {
+      resizeOpts.maxHeight = maxHeight
+    }
+    pipeline = pipeline.resize(resizeOpts)
+  }
+
   await pipeline.encode({ mimetype, maxBytes }).save(output)
 
   console.log(output)

--- a/bin.js
+++ b/bin.js
@@ -10,8 +10,8 @@ import {
   isStripMetadataSupported
 } from 'bare-media/types'
 import getMimeType from 'get-mime-type'
-import { detectMimeType } from './src/util'
 
+import { detectMimeType } from './src/util'
 import pkg from './package'
 
 const cli = command(

--- a/bin.js
+++ b/bin.js
@@ -70,10 +70,12 @@ async function metadata(parsed) {
   if (mimetype.startsWith('image/')) {
     if (parsed.flags.strip) {
       if (!isStripMetadataSupported(mimetype)) {
-        throw new Error(`Metadata stripping is not supported for ${mimetype}`)
+        console.log(`Metadata stripping is not supported for ${mimetype}`)
+        Bare.exit(1)
       }
       if (!parsed.args.output) {
-        throw new Error('Missing output path')
+        console.log('Missing output path')
+        Bare.exit(1)
       }
       const output = path.resolve(parsed.args.output)
       await image(input).metadata.strip().save(output)
@@ -91,13 +93,12 @@ async function metadata(parsed) {
     print(data, { json: parsed.flags.json })
   }
 
-  throw new Error('Not supported for ', mimetype)
+  console.log('Not supported for ', mimetype)
 }
 
 async function convert(parsed) {
   const input = validateInput(parsed.args.input)
-  const output = path.resolve(parsed.args.output)
-  let source = input
+  const output = validateOutput(parsed.args.output)
 
   const maxWidth = validateFlag(parsed.flags.maxWidth, '--max-width', 'number')
   const maxHeight = validateFlag(parsed.flags.maxHeight, '--max-height', 'number')
@@ -105,7 +106,7 @@ async function convert(parsed) {
   const maxBytes = validateFlag(parsed.flags.maxBytes, '--max-bytes', 'number')
   const mimetype = getMimeType(output)
 
-  let pipeline = image(source).decode({ maxFrames })
+  let pipeline = image(input).decode({ maxFrames })
   if (parsed.flags.orientate) pipeline = pipeline.orientate()
   if (maxWidth || maxHeight) {
     pipeline = pipeline.resize({
@@ -120,7 +121,7 @@ async function convert(parsed) {
 
 async function transcode(parsed) {
   const input = validateInput(parsed.args.input)
-  const output = path.resolve(parsed.args.output)
+  const output = validateOutput(parsed.args.output)
   const width = validateFlag(parsed.flags.width, '--width', 'number')
   const height = validateFlag(parsed.flags.height, '--height', 'number')
   const mimetype = getMimeType(output)
@@ -160,8 +161,19 @@ async function head(filePath, byteLength = 4100) {
 
 function validateInput(input) {
   const file = path.resolve(input)
-  if (!fs.existsSync(file)) throw new Error(`File not found: ${file}`)
+  if (!fs.existsSync(file)) {
+    console.error(`File not found: ${file}`)
+    Bare.exit(1)
+  }
   return file
+}
+
+function validateOutput(output) {
+  if (!output) {
+    console.error('Missing output')
+    Bare.exit(1)
+  }
+  return path.resolve(output)
 }
 
 function validateFlag(value, name, type) {
@@ -198,4 +210,19 @@ function print(value, opts = {}) {
   }
 }
 
-cli.parse()
+async function main() {
+  const parsed = cli.parse()
+  if (!parsed) return exit(cli.bailed)
+
+  if (parsed.running) await parsed.running
+  if (parsed.bailed) exit(parsed.bailed)
+}
+
+function exit(bailed) {
+  if (!bailed) return
+
+  console.error(bailed.output || bailed.bail?.reason || 'Command failed')
+  Bare.exit(1)
+}
+
+main()

--- a/bin.js
+++ b/bin.js
@@ -67,27 +67,31 @@ async function metadata(parsed) {
   const input = validateInput(parsed.args.input)
   const mimetype = detectMimeType(await head(input))
 
-  if (parsed.flags.strip) {
-    if (!isStripMetadataSupported(mimetype)) {
-      throw new Error(`Metadata stripping is not supported for ${mimetype}`)
-    }
-    if (!parsed.args.output) {
-      throw new Error('Missing output path')
-    }
-    const output = path.resolve(parsed.args.output)
-    await image(input).metadata.strip().save(output)
-    return
-  }
-
   if (mimetype.startsWith('image/')) {
+    if (parsed.flags.strip) {
+      if (!isStripMetadataSupported(mimetype)) {
+        throw new Error(`Metadata stripping is not supported for ${mimetype}`)
+      }
+      if (!parsed.args.output) {
+        throw new Error('Missing output path')
+      }
+      const output = path.resolve(parsed.args.output)
+      await image(input).metadata.strip().save(output)
+      return
+    }
+
     const data = await image(input).metadata()
     const out = data || { mimetype }
     print(out, { json: parsed.flags.json })
     return
   }
 
-  const data = await video(input).metadata()
-  print(data, { json: parsed.flags.json })
+  if (mimetype.startsWith('video/')) {
+    const data = await video(input).metadata()
+    print(data, { json: parsed.flags.json })
+  }
+
+  throw new Error('Not supported for ', mimetype)
 }
 
 async function convert(parsed) {

--- a/bin.js
+++ b/bin.js
@@ -1,0 +1,184 @@
+#!/usr/bin/env bare
+import { command, summary, arg, flag, bail } from 'paparam'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { image, video } from 'bare-media'
+import {
+  supportedImageMimetypes,
+  supportedVideoMimetypes,
+  isImageSupported,
+  isStripMetadataSupported
+} from 'bare-media/types'
+import getMimeType from 'get-mime-type'
+
+import pkg from './package'
+
+const cli = command(
+  pkg.name,
+  summary(pkg.description),
+  bail(({ reason, flag, arg }) => {
+    if (flag) return `Unknown or invalid flag: ${flag.long ? '--' : '-'}${flag.name}`
+    if (arg) return `Unknown argument: ${arg.value}`
+    return reason
+  }),
+  flag('--version|-v', 'Print version'),
+  command(
+    'metadata',
+    summary('Print image or video metadata (experimental)'),
+    arg('<input>', 'Input media file'),
+    arg('[output]', 'Output media file'),
+    flag('--strip', 'Strip image metadata'),
+    flag('--json|-j', 'Print JSON'),
+    metadata
+  ),
+  command(
+    'convert',
+    summary('Convert an image'),
+    arg('<input>', 'Input image file'),
+    arg('<output>', 'Output image file'),
+    flag('--max-width|-w <px>', 'Maximum output width'),
+    flag('--max-height|-h <px>', 'Maximum output height'),
+    flag('--max-frames|-f <n>', 'Maximum frames to decode'),
+    flag('--max-bytes|-n <n>', 'Maximum encoded size'),
+    flag('--orientate|-o', 'Apply EXIF orientation'),
+    convert
+  ),
+  command(
+    'transcode',
+    summary('Transcode a video'),
+    arg('<input>', 'Input video file'),
+    arg('<output>', 'Output video file'),
+    flag('--width <px>', 'Output width'),
+    flag('--height <px>', 'Output height'),
+    transcode
+  ),
+  command('types', summary('List supported MIME types'), types),
+  (cmd) => {
+    if (cmd.flags.version) {
+      console.log(pkg.version)
+      return
+    }
+    console.log(cli.usage())
+  }
+)
+
+async function metadata(parsed) {
+  const input = validateInput(parsed.args.input)
+  const mimetype = getMimeType(input)
+
+  if (parsed.flags.strip) {
+    if (!parsed.args.output) {
+      throw new Error('Missing output path')
+    }
+    const output = path.resolve(parsed.args.output)
+    const mimetype = getMimeType(input)
+    if (!isStripMetadataSupported(mimetype)) {
+      throw new Error(`Metadata stripping is not supported for ${mimetype}`)
+    }
+
+    await image(input).metadata.strip().save(output)
+    return
+  }
+
+  if (mimetype.startsWith('image/')) {
+    const data = await image(input).metadata()
+    const out = data || { mimetype }
+    print(out, { json: parsed.flags.json })
+    return
+  }
+
+  const data = await video(input).metadata()
+  print(data, { json: parsed.flags.json })
+}
+
+async function convert(parsed) {
+  const input = validateInput(parsed.args.input)
+  const output = path.resolve(parsed.args.output)
+  let source = input
+
+  const maxWidth = validateFlag(parsed.flags.maxWidth, '--max-width', 'number')
+  const maxHeight = validateFlag(parsed.flags.maxHeight, '--max-height', 'number')
+  const maxFrames = validateFlag(parsed.flags.maxFrames, '--max-frames', 'number')
+  const maxBytes = validateFlag(parsed.flags.maxBytes, '--max-bytes', 'number')
+  const mimetype = getMimeType(output)
+
+  let pipeline = image(source).decode({ maxFrames })
+  if (parsed.flags.orientate) pipeline = pipeline.orientate()
+  if (maxWidth || maxHeight) {
+    pipeline = pipeline.resize({
+      maxWidth: maxWidth || Number.MAX_SAFE_INTEGER,
+      maxHeight: maxHeight || Number.MAX_SAFE_INTEGER
+    })
+  }
+  await pipeline.encode({ mimetype, maxBytes }).save(output)
+
+  console.log(output)
+}
+
+async function transcode(parsed) {
+  const input = validateInput(parsed.args.input)
+  const output = path.resolve(parsed.args.output)
+  const width = validateFlag(parsed.flags.width, '--width', 'number')
+  const height = validateFlag(parsed.flags.height, '--height', 'number')
+  const mimetype = getMimeType(output)
+  const format = mimetype.split('/')[1]
+
+  const chunks = video(input).transcode({ format, width, height })
+  const fd = fs.openSync(output, 'w')
+  try {
+    for await (const chunk of chunks) fs.writeSync(fd, chunk.buffer)
+  } finally {
+    fs.closeSync(fd)
+  }
+
+  console.log(output)
+}
+
+function types() {
+  console.log('Images:')
+  for (const mimetype of supportedImageMimetypes) console.log(`  ${mimetype}`)
+  console.log('Videos:')
+  for (const mimetype of supportedVideoMimetypes) console.log(`  ${mimetype}`)
+}
+
+function validateInput(input) {
+  const file = path.resolve(input)
+  if (!fs.existsSync(file)) throw new Error(`File not found: ${file}`)
+  return file
+}
+
+function validateFlag(value, name, type) {
+  if (type === 'number' && value !== undefined) {
+    return Number.parseInt(value)
+  }
+  return value
+}
+
+function print(value, opts = {}) {
+  const { prefix = '', json = false } = opts
+
+  if (json) {
+    console.log(JSON.stringify(value, null, 2))
+    return
+  }
+
+  for (const [key, entry] of Object.entries(value)) {
+    if (entry && typeof entry === 'object') {
+      if (Buffer.isBuffer(entry)) {
+        console.log(`${prefix}${key}:`, entry.toString())
+      } else if (Array.isArray(entry)) {
+        console.log(`${prefix}${key}:`)
+        for (const value of entry) {
+          print(value, { prefix: `${prefix}  ` })
+        }
+      } else {
+        console.log(`${prefix}${key}:`)
+        print(entry, { prefix: `${prefix}  ` })
+      }
+    } else {
+      console.log(`${prefix}${key}: ${String(entry)}`)
+    }
+  }
+}
+
+cli.parse()

--- a/bin.js
+++ b/bin.js
@@ -38,7 +38,7 @@ const cli = command(
     arg('<input>', 'Input image file'),
     arg('<output>', 'Output image file'),
     flag('--max-width|-w <px>', 'Maximum output width'),
-    flag('--max-height|-h <px>', 'Maximum output height'),
+    flag('--max-height|-H <px>', 'Maximum output height'),
     flag('--max-frames|-f <n>', 'Maximum frames to decode'),
     flag('--max-bytes|-n <n>', 'Maximum encoded size'),
     flag('--orientate|-o', 'Apply EXIF orientation'),

--- a/bin.js
+++ b/bin.js
@@ -91,6 +91,7 @@ async function metadata(parsed) {
   if (mimetype.startsWith('video/')) {
     const data = await video(input).metadata()
     print(data, { json: parsed.flags.json })
+    return
   }
 
   console.log('Not supported for ', mimetype)

--- a/bin.js
+++ b/bin.js
@@ -94,7 +94,7 @@ async function metadata(parsed) {
     return
   }
 
-  console.log('Not supported for ', mimetype)
+  console.log('Not supported for mimetype', mimetype)
 }
 
 async function convert(parsed) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "index.js",
     "types.js"
   ],
+  "bin": {
+    "bare-media": "./bin.js",
+    "bm": "./bin.js"
+  },
   "scripts": {
     "format": "prettier --write . && lunte --fix",
     "lint": "prettier --check . && lunte",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "bare-tiff": "^1.0.1",
     "bare-webp": "^1.0.3",
     "get-file-format": "^1.1.0",
-    "get-mime-type": "^2.0.1"
+    "get-mime-type": "^2.0.1",
+    "paparam": "^1.10.1"
   },
   "devDependencies": {
     "b4a": "^1.7.3",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,7 @@
     "types.js"
   ],
   "bin": {
-    "bare-media": "./bin.js",
-    "bm": "./bin.js"
+    "bare-media": "./bin.js"
   },
   "scripts": {
     "format": "prettier --write . && lunte --fix",

--- a/src/image.js
+++ b/src/image.js
@@ -164,7 +164,7 @@ async function resize(rgba, opts = {}) {
 
   let maybeResizedRGBA
 
-  if (maxWidth && maxHeight && (width > maxWidth || height > maxHeight)) {
+  if ((maxWidth || maxHeight) && (width > maxWidth || height > maxHeight)) {
     const { resize } = await import('bare-image-resample')
     const dimensions = calculateFitDimensions(width, height, maxWidth, maxHeight)
     if (Array.isArray(rgba.frames)) {

--- a/src/util.js
+++ b/src/util.js
@@ -5,7 +5,7 @@ export function detectMimeType(buffer) {
   return getMimeType(getFileFormat(buffer))
 }
 
-export function calculateFitDimensions(width, height, maxWidth, maxHeight) {
+export function calculateFitDimensions(width, height, maxWidth = Infinity, maxHeight = Infinity) {
   if (width <= maxWidth && height <= maxHeight) {
     return { width, height }
   }


### PR DESCRIPTION
Adds CLI support:

```sh
bare-media [flags] [command]

A set of media APIs for Bare

Flags:
  --version|-v   Print version
  --help|-h      Show help

Commands:
  metadata       Print image or video metadata (experimental)
  convert        Convert an image
  transcode      Transcode a video
  types          List supported MIME types
```

Also, the `resize` function had the constraint of having to pass both `maxWidth` and `maxHeight`. This has been removed giving the option to resize passing only one max side.