### PR TITLE
Fix missing duration in transcoded video

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "bare-bmp": "^1.0.0",
     "bare-exif": "^1.1.0",
     "bare-fetch": "^3.0.1",
-    "bare-ffmpeg": "^1.3.0",
+    "bare-ffmpeg": "^1.5.0",
     "bare-fs": "^4.1.5",
     "bare-gif": "^1.1.2",
     "bare-heif": "^1.0.5",

--- a/src/video/transcoder.js
+++ b/src/video/transcoder.js
@@ -463,6 +463,15 @@ class Transcoder {
     const options = formatRegistry.getMuxerOptions(this.containerFormat)
     const muxerOptions = ffmpeg.Dictionary.from(options)
 
+    const duration = this.inputFormatContext.duration
+    if (duration > 0) {
+      this.outputFormatContext.duration = duration
+
+      if (muxerOptions.get('live') === '1') {
+        muxerOptions.set('live', '0')
+      }
+    }
+
     this.outputFormatContext.writeHeader(muxerOptions)
   }
 

--- a/test/video.js
+++ b/test/video.js
@@ -1,10 +1,12 @@
 import { test } from 'brittle'
 import fs from 'bare-fs'
 import b4a from 'b4a'
+import os from 'bare-os'
+import barePath from 'bare-path'
 
 import { video } from '..'
 import { parseDisplayMatrix } from '../src/video/metadata'
-import { createDisplayMatrix } from './helpers'
+import { createDisplayMatrix, randomFileName } from './helpers'
 
 test('video extractFrames()', async (t) => {
   const path = './test/fixtures/sample.mp4'
@@ -192,6 +194,33 @@ test('video.transcode() - mp4 to webm', async (t) => {
   t.is(totalOutputBuffer[1], 0x45, 'Output starts with EBML header byte 1')
   t.is(totalOutputBuffer[2], 0xdf, 'Output starts with EBML header byte 2')
   t.is(totalOutputBuffer[3], 0xa3, 'Output starts with EBML header byte 3')
+})
+
+test.solo('video.transcode() - mp4 to webm has metadata', async (t) => {
+  const path = './test/fixtures/sample.mp4'
+  const outputPath = barePath.join(os.tmpdir(), randomFileName('webm'))
+  t.teardown(() => fs.unlinkSync(outputPath))
+
+  const fd = fs.openSync(outputPath, 'w')
+  try {
+    for await (const chunk of video(path).transcode({ format: 'webm' })) {
+      fs.writeSync(fd, chunk.buffer)
+    }
+  } finally {
+    fs.closeSync(fd)
+  }
+
+  const metadata = await video(outputPath).metadata()
+  const constants = await video.getConstants()
+
+  t.is(metadata.width, 320, 'width is set')
+  t.is(metadata.height, 240, 'height is set')
+  t.is(metadata.codec.id, constants.codecs.VP9, 'codec is VP9')
+  t.is(metadata.codec.name, 'vp9', 'codec name is set')
+  t.is(metadata.avgFramerate.numerator, 25, 'framerate numerator is set')
+  t.is(metadata.avgFramerate.denominator, 1, 'framerate denominator is set')
+  t.is(metadata.duration, 4, 'duration is set')
+  t.is(metadata.displayRotation, 0, 'rotation is set')
 })
 
 test('video.transcode() - mp4 to webm with stereo', async (t) => {

--- a/test/video.js
+++ b/test/video.js
@@ -196,7 +196,7 @@ test('video.transcode() - mp4 to webm', async (t) => {
   t.is(totalOutputBuffer[3], 0xa3, 'Output starts with EBML header byte 3')
 })
 
-test.solo('video.transcode() - mp4 to webm has metadata', async (t) => {
+test('video.transcode() - mp4 to webm has metadata', async (t) => {
   const path = './test/fixtures/sample.mp4'
   const outputPath = barePath.join(os.tmpdir(), randomFileName('webm'))
   t.teardown(() => fs.unlinkSync(outputPath))


### PR DESCRIPTION
Sets the duration to the output format if known upfront. WebM live mode must be disabled for ffmpeg to write it.