### PR TITLE
Add presets for video transcoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ Transcode a media file to a different format
 | `opts.format` | string | Output format name (e.g., `mp4`, `webm`, `matroska`). Default `mp4` |
 | `opts.width`  | number | Width of the output video                                           |
 | `opts.height` | number | Height of the output video                                          |
-| `opts.preset` | string | Encoding preset: `fast`, `compact`, `best`, or `balanced` (default) |
+| `opts.preset` | string | Encoding preset: `fast`, `quality`, `best`, or `balanced` (default) |
 
 **Supported formats**: `mp4` (VP9+Opus), `webm` (VP9+Opus), `matroska`/`mkv` (VP9+Opus)
 
@@ -231,8 +231,8 @@ Presets choose a tradeoff between conversion speed, visual quality, and file siz
 
 | Preset     | Prioritizes                  | Tradeoff             |
 | ---------- | ---------------------------- | -------------------- |
-| `fast`     | Speed and visual quality     | Larger files         |
-| `compact`  | Speed and smaller files      | Lower visual quality |
+| `fast`     | Speed and smaller files      | Lower visual quality |
+| `quality`  | Speed and visual quality     | Larger files         |
 | `best`     | Visual quality and file size | Slower conversion    |
 | `balanced` | A balance of all three       | Balanced tradeoffs   |
 

--- a/README.md
+++ b/README.md
@@ -223,8 +223,18 @@ Transcode a media file to a different format
 | `opts.format` | string | Output format name (e.g., `mp4`, `webm`, `matroska`). Default `mp4` |
 | `opts.width`  | number | Width of the output video                                           |
 | `opts.height` | number | Height of the output video                                          |
+| `opts.preset` | string | Encoding preset: `fast`, `compact`, `best`, or `balanced` (default) |
 
 **Supported formats**: `mp4` (VP9+Opus), `webm` (VP9+Opus), `matroska`/`mkv` (VP9+Opus)
+
+Presets choose a tradeoff between conversion speed, visual quality, and file size:
+
+| Preset     | Prioritizes                  | Tradeoff             |
+| ---------- | ---------------------------- | -------------------- |
+| `fast`     | Speed and visual quality     | Larger files         |
+| `compact`  | Speed and smaller files      | Lower visual quality |
+| `best`     | Visual quality and file size | Slower conversion    |
+| `balanced` | A balance of all three       | Balanced tradeoffs   |
 
 #### Example
 
@@ -233,6 +243,7 @@ import { video } from 'bare-media'
 
 for await (const chunk of video('input.mkv').transcode({
   format: 'mp4',
+  preset: 'fast',
   width: 1280,
   height: 720
 })) {

--- a/bin.js
+++ b/bin.js
@@ -51,6 +51,7 @@ const cli = command(
     arg('<output>', 'Output video file'),
     flag('--width <px>', 'Output width'),
     flag('--height <px>', 'Output height'),
+    flag('--preset <name>', 'Encoding preset (fast, compact, best, or balanced)'),
     transcode
   ),
   command('types', summary('List supported MIME types'), types),
@@ -134,10 +135,11 @@ async function transcode(parsed) {
   const output = validateOutput(parsed.args.output)
   const width = validateFlag(parsed.flags.width, '--width', 'number')
   const height = validateFlag(parsed.flags.height, '--height', 'number')
+  const preset = parsed.flags.preset
   const mimetype = getMimeType(output)
   const format = mimetype.split('/')[1]
 
-  const chunks = video(input).transcode({ format, width, height })
+  const chunks = video(input).transcode({ format, width, height, preset })
   const fd = fs.openSync(output, 'w')
   try {
     for await (const chunk of chunks) fs.writeSync(fd, chunk.buffer)

--- a/bin.js
+++ b/bin.js
@@ -51,7 +51,7 @@ const cli = command(
     arg('<output>', 'Output video file'),
     flag('--width <px>', 'Output width'),
     flag('--height <px>', 'Output height'),
-    flag('--preset <name>', 'Encoding preset (fast, compact, best, or balanced)'),
+    flag('--preset <name>', 'Encoding preset (fast, quality, best, or balanced)'),
     transcode
   ),
   command('types', summary('List supported MIME types'), types),

--- a/src/video.js
+++ b/src/video.js
@@ -81,7 +81,8 @@ async function* transcode(fd, opts = {}) {
       width: opts.width,
       height: opts.height
     },
-    bufferSize: opts.bufferSize
+    bufferSize: opts.bufferSize,
+    preset: opts.preset
   })
 
   yield* transcoder.transcode()

--- a/src/video/transcoder.js
+++ b/src/video/transcoder.js
@@ -10,12 +10,12 @@ const encoderPresets = {
   fast: {
     deadline: 'realtime',
     'cpu-used': '8',
-    crf: '26'
+    crf: '42'
   },
-  compact: {
+  quality: {
     deadline: 'realtime',
     'cpu-used': '8',
-    crf: '42'
+    crf: '26'
   },
   best: {
     deadline: 'good',

--- a/src/video/transcoder.js
+++ b/src/video/transcoder.js
@@ -4,6 +4,31 @@ import ffmpeg from 'bare-ffmpeg'
 
 const { VIDEO, AUDIO } = ffmpeg.constants.mediaTypes
 
+const DEFAULT_PRESET = 'balanced'
+
+const encoderPresets = {
+  fast: {
+    deadline: 'realtime',
+    'cpu-used': '8',
+    crf: '26'
+  },
+  compact: {
+    deadline: 'realtime',
+    'cpu-used': '8',
+    crf: '42'
+  },
+  best: {
+    deadline: 'good',
+    'cpu-used': '2',
+    crf: '26'
+  },
+  balanced: {
+    deadline: 'realtime',
+    'cpu-used': '6',
+    crf: '34'
+  }
+}
+
 class FormatRegistry {
   #formats = new Map()
 
@@ -104,21 +129,23 @@ formatRegistry.register('mkv', {
 })
 
 class TranscodeStreamConfig {
-  static create(inputStream, outputFormatContext, containerFormat, outputParameters) {
+  static create(inputStream, outputFormatContext, containerFormat, outputParameters, preset) {
     const config = new TranscodeStreamConfig(
       inputStream,
       outputFormatContext,
       containerFormat,
-      outputParameters
+      outputParameters,
+      preset
     )
     return config.#initialize() ? config : null
   }
 
-  constructor(inputStream, outputFormatContext, containerFormat, outputParameters) {
+  constructor(inputStream, outputFormatContext, containerFormat, outputParameters, preset) {
     this.inputStream = inputStream
     this.outputFormatContext = outputFormatContext
     this.containerFormat = containerFormat
     this.outputParameters = outputParameters
+    this.preset = preset
     this.codecType = inputStream.codecParameters.type
 
     this.outputStream = null
@@ -212,10 +239,8 @@ class TranscodeStreamConfig {
 
     const encoderOptions = this.isVideo()
       ? ffmpeg.Dictionary.from({
+          ...encoderPresets[this.preset],
           allow_sw: '1',
-          deadline: 'good',
-          'cpu-used': '6',
-          crf: '30',
           b: '0'
         })
       : new ffmpeg.Dictionary()
@@ -375,6 +400,11 @@ class Transcoder {
     this.fd = fd
     this.outputParameters = opts.outputParameters || {}
     this.bufferSize = opts.bufferSize || 32 * 1024
+    this.preset = opts.preset ?? DEFAULT_PRESET
+
+    if (!Object.hasOwn(encoderPresets, this.preset)) {
+      throw new Error(`Unsupported preset: ${this.preset}`)
+    }
 
     this.chunks = []
     this.currentTime = 0
@@ -450,7 +480,8 @@ class Transcoder {
         inputStream,
         this.outputFormatContext,
         this.containerFormat,
-        this.outputParameters
+        this.outputParameters,
+        this.preset
       )
 
       if (config) {

--- a/test/video.js
+++ b/test/video.js
@@ -467,6 +467,40 @@ test('video.transcode() - throws error for unsupported format', async (t) => {
   }, /Unsupported.*output format/)
 })
 
+test('video.transcode() - encoding presets', async (t) => {
+  const path = './test/fixtures/duration-stream.mp4'
+  const outputs = new Map()
+
+  for (const preset of ['fast', 'compact', 'best', 'balanced']) {
+    const chunks = []
+
+    for await (const chunk of video(path).transcode({ format: 'webm', preset })) {
+      chunks.push(chunk.buffer)
+    }
+
+    const output = b4a.concat(chunks)
+    outputs.set(preset, output)
+
+    t.ok(output.length > 0, `${preset} preset produces output`)
+    t.is(output[0], 0x1a, `${preset} preset produces WebM`)
+  }
+
+  const chunks = []
+  for await (const chunk of video(path).transcode({ format: 'webm' })) {
+    chunks.push(chunk.buffer)
+  }
+
+  t.is(b4a.concat(chunks).length, outputs.get('balanced').length, 'balanced is the default preset')
+})
+
+test('video.transcode() - throws error for unsupported preset', async (t) => {
+  const path = './test/fixtures/sample.mp4'
+
+  await t.exception(async () => {
+    for await (const chunk of video(path).transcode({ preset: 'unknown' }));
+  }, /Unsupported preset: unknown/)
+})
+
 function isValidTime(time) {
   return Number.isFinite(time) && time >= 0
 }

--- a/test/video.js
+++ b/test/video.js
@@ -471,7 +471,7 @@ test('video.transcode() - encoding presets', async (t) => {
   const path = './test/fixtures/duration-stream.mp4'
   const outputs = new Map()
 
-  for (const preset of ['fast', 'compact', 'best', 'balanced']) {
+  for (const preset of ['fast', 'quality', 'best', 'balanced']) {
     const chunks = []
 
     for await (const chunk of video(path).transcode({ format: 'webm', preset })) {


### PR DESCRIPTION
Each preset considers three factors: "conversion speed", "visual quality" and "file size", maximizing 2 at the expense of the third, except for the balanced one which makes moderate tradeoffs across all three.

| Preset     | Maximizes                  | Tradeoff             |
| ---------- | ---------------------------- | -------------------- |
| `fast`     | Speed and smaller files      | Lower visual quality |
| `quality`  | Speed and visual quality     | Larger files         |
| `best`     | Visual quality and file size | Slower conversion    |
| `balanced` | A balance of all three       | Balanced tradeoffs   |