### PR TITLE
Add image and video benchmarks

### DIFF
--- a/bench/benchmark.js
+++ b/bench/benchmark.js
@@ -1,0 +1,30 @@
+import performance from 'bare-performance'
+import process from 'bare-process'
+
+export default async function benchmark(run) {
+  const baseline = maxRss()
+  const cpuBefore = process.cpuUsage()
+  const start = performance.now()
+
+  await run()
+
+  const duration = performance.now() - start
+  const cpu = process.cpuUsage(cpuBefore)
+  const cpuDuration = (cpu.user + cpu.system) / 1000
+  const peak = maxRss()
+
+  console.log(
+    JSON.stringify({
+      duration,
+      cpuDuration,
+      cpuUtilization: (cpuDuration / duration) * 100,
+      baseline,
+      peak,
+      delta: peak - baseline
+    })
+  )
+}
+
+function maxRss() {
+  return process.resourceUsage().maxRSS * 1024
+}

--- a/bench/benchmark.js
+++ b/bench/benchmark.js
@@ -2,15 +2,16 @@ import performance from 'bare-performance'
 import process from 'bare-process'
 
 export default async function benchmark(run) {
-  const baseline = maxRss()
+  const baseline = rss()
   const cpuBefore = process.cpuUsage()
   const start = performance.now()
 
-  await run()
+  const resultKeptFromGC = await run()
 
   const duration = performance.now() - start
   const cpu = process.cpuUsage(cpuBefore)
   const cpuDuration = (cpu.user + cpu.system) / 1000
+  const current = rss()
   const peak = maxRss()
 
   console.log(
@@ -19,10 +20,17 @@ export default async function benchmark(run) {
       cpuDuration,
       cpuUtilization: (cpuDuration / duration) * 100,
       baseline,
+      current,
       peak,
-      delta: peak - baseline
+      delta: current - baseline
     })
   )
+
+  return resultKeptFromGC
+}
+
+function rss() {
+  return process.memoryUsage().rss
 }
 
 function maxRss() {

--- a/bench/benchmark.js
+++ b/bench/benchmark.js
@@ -2,37 +2,37 @@ import performance from 'bare-performance'
 import process from 'bare-process'
 
 export default async function benchmark(run) {
-  const baseline = rss()
+  const rssBefore = getRss()
   const cpuBefore = process.cpuUsage()
   const start = performance.now()
 
   const resultKeptFromGC = await run()
 
-  const duration = performance.now() - start
+  const ms = performance.now() - start
   const cpu = process.cpuUsage(cpuBefore)
-  const cpuDuration = (cpu.user + cpu.system) / 1000
-  const current = rss()
-  const peak = maxRss()
+  const cpuMs = (cpu.user + cpu.system) / 1000
+  const rssAfter = getRss()
+  const rssPeak = getRssPeak()
 
   console.log(
     JSON.stringify({
-      duration,
-      cpuDuration,
-      cpuUtilization: (cpuDuration / duration) * 100,
-      baseline,
-      current,
-      peak,
-      delta: current - baseline
+      ms,
+      cpuMs,
+      cpuPercent: (cpuMs / ms) * 100,
+      rssBefore,
+      rssAfter,
+      rssPeak,
+      rssDiff: rssAfter - rssBefore
     })
   )
 
   return resultKeptFromGC
 }
 
-function rss() {
+function getRss() {
   return process.memoryUsage().rss
 }
 
-function maxRss() {
+function getRssPeak() {
   return process.resourceUsage().maxRSS * 1024
 }

--- a/bench/benchmark.js
+++ b/bench/benchmark.js
@@ -12,7 +12,7 @@ export default async function benchmark(run) {
   const cpu = process.cpuUsage(cpuBefore)
   const cpuMs = (cpu.user + cpu.system) / 1000
   const rssAfter = getRss()
-  const rssPeak = getRssPeak()
+  const rssMax = getRssMax()
 
   console.log(
     JSON.stringify({
@@ -21,7 +21,7 @@ export default async function benchmark(run) {
       cpuPercent: (cpuMs / ms) * 100,
       rssBefore,
       rssAfter,
-      rssPeak,
+      rssMax,
       rssDiff: rssAfter - rssBefore
     })
   )
@@ -33,6 +33,6 @@ function getRss() {
   return process.memoryUsage().rss
 }
 
-function getRssPeak() {
+function getRssMax() {
   return process.resourceUsage().maxRSS * 1024
 }

--- a/bench/image/crop.js
+++ b/bench/image/crop.js
@@ -1,0 +1,16 @@
+import process from 'bare-process'
+
+import { image } from '../..'
+import benchmark from '../benchmark'
+
+const filename = process.argv[2]
+const rgba = await image(filename).decode()
+
+await benchmark(() =>
+  image.crop(rgba, {
+    left: 0,
+    top: 0,
+    width: Math.floor(rgba.width / 2),
+    height: Math.floor(rgba.height / 2)
+  })
+)

--- a/bench/image/decode.js
+++ b/bench/image/decode.js
@@ -1,0 +1,8 @@
+import process from 'bare-process'
+
+import { image } from '../..'
+import benchmark from '../benchmark'
+
+const filename = process.argv[2]
+
+await benchmark(() => image(filename).decode())

--- a/bench/image/encode.js
+++ b/bench/image/encode.js
@@ -1,0 +1,9 @@
+import process from 'bare-process'
+
+import { image } from '../..'
+import benchmark from '../benchmark'
+
+const filename = process.argv[2]
+const rgba = await image(filename).decode()
+
+await benchmark(() => image.encode(rgba, { mimetype: 'image/webp' }))

--- a/bench/image/flip.js
+++ b/bench/image/flip.js
@@ -1,0 +1,9 @@
+import process from 'bare-process'
+
+import { image } from '../..'
+import benchmark from '../benchmark'
+
+const filename = process.argv[2]
+const rgba = await image(filename).decode()
+
+await benchmark(() => image.flip(rgba, { h: true }))

--- a/bench/image/resize.js
+++ b/bench/image/resize.js
@@ -1,0 +1,9 @@
+import process from 'bare-process'
+
+import { image } from '../..'
+import benchmark from '../benchmark'
+
+const filename = process.argv[2]
+const rgba = await image(filename).decode()
+
+await benchmark(() => image.resize(rgba, { maxWidth: 64, maxHeight: 64 }))

--- a/bench/image/rotate.js
+++ b/bench/image/rotate.js
@@ -1,0 +1,9 @@
+import process from 'bare-process'
+
+import { image } from '../..'
+import benchmark from '../benchmark'
+
+const filename = process.argv[2]
+const rgba = await image(filename).decode()
+
+await benchmark(() => image.rotate(rgba, { deg: 90 }))

--- a/bench/index.js
+++ b/bench/index.js
@@ -30,7 +30,7 @@ for (const suite of suites) {
   const media = samples.filter((sample) => getMimeType(sample)?.startsWith(suite.mimetype))
   if (media.length === 0) continue
 
-  console.log(`${suite.name} benchmark time, CPU, and peak RSS`)
+  console.log(`${suite.name} benchmark time, CPU, peak RSS, and RSS change`)
 
   for (const benchmark of suite.benchmarks) {
     console.log(`\n${benchmark}`)
@@ -56,8 +56,13 @@ for (const suite of suites) {
 
 function printResult(sample, result) {
   console.log(
-    `${sample.padEnd(16)} ${result.duration.toFixed(2).padStart(8)} ms  ${result.cpuDuration.toFixed(2).padStart(8)} ms CPU (${result.cpuUtilization.toFixed(1)}%)  ${formatBytes(result.peak).padStart(10)} peak  ${`+${formatBytes(result.delta)}`.padStart(10)}`
+    `${sample.padEnd(16)} ${result.duration.toFixed(2).padStart(8)} ms  ${result.cpuDuration.toFixed(2).padStart(8)} ms CPU (${result.cpuUtilization.toFixed(1)}%)  ${formatBytes(result.peak).padStart(10)} peak  ${formatDelta(result.delta).padStart(10)}`
   )
+}
+
+function formatDelta(bytes) {
+  const sign = bytes >= 0 ? '+' : '-'
+  return `${sign}${formatBytes(Math.abs(bytes))}`
 }
 
 function formatBytes(bytes) {

--- a/bench/index.js
+++ b/bench/index.js
@@ -1,4 +1,5 @@
 import { readdir } from 'bare-fs/promises'
+import { fileURLToPath } from 'bare-url'
 import { join } from 'bare-path'
 import process from 'bare-process'
 import { spawnSync } from 'bare-subprocess'
@@ -6,7 +7,8 @@ import getMimeType from 'get-mime-type'
 
 import downloadSamples from '../test/samples/download'
 
-const samplesDir = join('test', 'samples', 'files', 'benchmark')
+const abs = fileURLToPath(new URL('..', import.meta.url))
+const samplesDir = join(abs, 'test', 'samples', 'files', 'benchmark')
 const suites = [
   {
     name: 'Image',

--- a/bench/index.js
+++ b/bench/index.js
@@ -1,0 +1,65 @@
+import { readdir } from 'bare-fs/promises'
+import { join } from 'bare-path'
+import process from 'bare-process'
+import { spawnSync } from 'bare-subprocess'
+import getMimeType from 'get-mime-type'
+
+import downloadSamples from '../test/samples/download'
+
+const samplesDir = join('test', 'samples', 'files', 'benchmark')
+const suites = [
+  {
+    name: 'Image',
+    directory: 'image',
+    benchmarks: ['decode', 'resize', 'crop', 'rotate', 'flip', 'encode'],
+    mimetype: 'image/'
+  },
+  {
+    name: 'Video',
+    directory: 'video',
+    benchmarks: ['metadata', 'extract-frames', 'transcode'],
+    mimetype: 'video/'
+  }
+]
+
+await downloadSamples()
+
+const samples = (await readdir(samplesDir)).filter((name) => !name.startsWith('.')).sort()
+
+for (const suite of suites) {
+  const media = samples.filter((sample) => getMimeType(sample)?.startsWith(suite.mimetype))
+  if (media.length === 0) continue
+
+  console.log(`${suite.name} benchmark time, CPU, and peak RSS`)
+
+  for (const benchmark of suite.benchmarks) {
+    console.log(`\n${benchmark}`)
+
+    for (const sample of media) {
+      const child = spawnSync(
+        process.execPath,
+        [join('bench', suite.directory, `${benchmark}.js`), join(samplesDir, sample)],
+        {
+          cwd: process.cwd(),
+          stdio: ['ignore', 'pipe', 'pipe']
+        }
+      )
+
+      if (child.status !== 0) throw new Error(child.stderr.toString())
+
+      printResult(sample, JSON.parse(child.stdout.toString()))
+    }
+  }
+
+  console.log()
+}
+
+function printResult(sample, result) {
+  console.log(
+    `${sample.padEnd(16)} ${result.duration.toFixed(2).padStart(8)} ms  ${result.cpuDuration.toFixed(2).padStart(8)} ms CPU (${result.cpuUtilization.toFixed(1)}%)  ${formatBytes(result.peak).padStart(10)} peak  ${`+${formatBytes(result.delta)}`.padStart(10)}`
+  )
+}
+
+function formatBytes(bytes) {
+  return `${(bytes / 1024 / 1024).toFixed(2)} MB`
+}

--- a/bench/index.js
+++ b/bench/index.js
@@ -30,7 +30,7 @@ for (const suite of suites) {
   const media = samples.filter((sample) => getMimeType(sample)?.startsWith(suite.mimetype))
   if (media.length === 0) continue
 
-  console.log(`${suite.name} benchmark time, CPU, peak RSS, and RSS change`)
+  console.log(`${suite.name} benchmark time, CPU, peak RSS, and RSS diff`)
 
   for (const benchmark of suite.benchmarks) {
     console.log(`\n${benchmark}`)
@@ -56,11 +56,11 @@ for (const suite of suites) {
 
 function printResult(sample, result) {
   console.log(
-    `${sample.padEnd(16)} ${result.duration.toFixed(2).padStart(8)} ms  ${result.cpuDuration.toFixed(2).padStart(8)} ms CPU (${result.cpuUtilization.toFixed(1)}%)  ${formatBytes(result.peak).padStart(10)} peak  ${formatDelta(result.delta).padStart(10)}`
+    `${sample.padEnd(16)} ${result.ms.toFixed(2).padStart(8)} ms  ${result.cpuMs.toFixed(2).padStart(8)} ms CPU (${result.cpuPercent.toFixed(1)}%)  ${formatBytes(result.rssPeak).padStart(10)} peak  ${formatRssDiff(result.rssDiff).padStart(10)}`
   )
 }
 
-function formatDelta(bytes) {
+function formatRssDiff(bytes) {
   const sign = bytes >= 0 ? '+' : '-'
   return `${sign}${formatBytes(Math.abs(bytes))}`
 }

--- a/bench/index.js
+++ b/bench/index.js
@@ -30,7 +30,7 @@ for (const suite of suites) {
   const media = samples.filter((sample) => getMimeType(sample)?.startsWith(suite.mimetype))
   if (media.length === 0) continue
 
-  console.log(`${suite.name} benchmark time, CPU, peak RSS, and RSS diff`)
+  console.log(`${suite.name} benchmark time, CPU, RSS diff, and max RSS`)
 
   for (const benchmark of suite.benchmarks) {
     console.log(`\n${benchmark}`)
@@ -56,7 +56,7 @@ for (const suite of suites) {
 
 function printResult(sample, result) {
   console.log(
-    `${sample.padEnd(16)} ${result.ms.toFixed(2).padStart(8)} ms  ${result.cpuMs.toFixed(2).padStart(8)} ms CPU (${result.cpuPercent.toFixed(1)}%)  ${formatBytes(result.rssPeak).padStart(10)} peak  ${formatRssDiff(result.rssDiff).padStart(10)}`
+    `${sample.padEnd(16)} ${result.ms.toFixed(2).padStart(8)} ms  ${result.cpuMs.toFixed(2).padStart(8)} ms CPU (${result.cpuPercent.toFixed(1)}%)  ${formatRssDiff(result.rssDiff).padStart(10)}  ${formatBytes(result.rssMax).padStart(10)} max`
   )
 }
 

--- a/bench/video/extract-frames.js
+++ b/bench/video/extract-frames.js
@@ -1,0 +1,8 @@
+import process from 'bare-process'
+
+import { video } from '../..'
+import benchmark from '../benchmark'
+
+const filename = process.argv[2]
+
+await benchmark(() => video(filename).extractFrames({ frameIndex: 0 }))

--- a/bench/video/metadata.js
+++ b/bench/video/metadata.js
@@ -1,0 +1,8 @@
+import process from 'bare-process'
+
+import { video } from '../..'
+import benchmark from '../benchmark'
+
+const filename = process.argv[2]
+
+await benchmark(() => video(filename).metadata())

--- a/bench/video/transcode.js
+++ b/bench/video/transcode.js
@@ -1,0 +1,16 @@
+import process from 'bare-process'
+
+import { video } from '../..'
+import benchmark from '../benchmark'
+
+const filename = process.argv[2]
+
+await benchmark(async () => {
+  let bytes = 0
+
+  for await (const chunk of video(filename).transcode({ format: 'mp4' })) {
+    bytes += chunk.buffer.byteLength
+  }
+
+  return bytes
+})

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "bare-media": "./bin.js"
   },
   "scripts": {
+    "bench": "bare bench/index.js",
     "format": "prettier --write . && lunte --fix",
     "lint": "prettier --check . && lunte",
     "test": "brittle-bare --coverage test.js"
@@ -58,6 +59,7 @@
     "bare-path": "^3.0.0",
     "bare-performance": "^1.3.0",
     "bare-process": "^4.2.2",
+    "bare-subprocess": "^5.2.3",
     "brittle": "^3.16.3",
     "corestore": "^7.4.5",
     "hyperblobs": "^2.8.0",

--- a/test/samples/download.js
+++ b/test/samples/download.js
@@ -30,6 +30,7 @@ async function download() {
   swarm.on('connection', (socket) => store.replicate(socket))
 
   try {
+    console.log('Downloading samples...\n')
     await drive.ready()
     swarm.join(drive.discoveryKey)
     const done = store.findingPeers()
@@ -77,7 +78,7 @@ async function verify() {
     }
   }
 
-  console.log(`Verified ${verified} sample files`)
+  console.log(`Verified ${verified} sample files\n`)
 }
 
 async function sha256(filename) {

--- a/test/samples/suites/benchmark.json
+++ b/test/samples/suites/benchmark.json
@@ -1,0 +1,63 @@
+{
+  "catalog": {
+    "path": "files/benchmark",
+    "samples": [
+      {
+        "path": "animated.gif",
+        "sha256": "674ef1b180a59b52770dca5f0380b00ccccc6fccc7cafc4c00e225acc9291b7e"
+      },
+      {
+        "path": "animated.webp",
+        "sha256": "4325d0a6ef83a09e2e07eac6959c49f874047ad4a99114582439a224bcd12ba1"
+      },
+      {
+        "path": "clip-av1.webm",
+        "sha256": "3967935980ce8b3892db4334182db259e2363f5ba0ed666adfad754052991258"
+      },
+      {
+        "path": "clip-h264.mkv",
+        "sha256": "daa1e8e489b1f3e810d3b540dce4b680f26bae1818d441d9ed42980408d17054"
+      },
+      {
+        "path": "clip-h264.mp4",
+        "sha256": "3978bdff764608147065508db0fd4d8ae5f8cefb1e38ae3def398a496f4a6d73"
+      },
+      {
+        "path": "clip-hevc.mp4",
+        "sha256": "4d4c21b24a0d2d5fd2f62af86a2bd9db8d71b236bd6789a4b2bc565f3331d519"
+      },
+      {
+        "path": "clip-vp9.webm",
+        "sha256": "8db7bff0b4f16c68c0fbf5ee9e1eb6b54b474e007f75fed4f57bae0485ee0132"
+      },
+      {
+        "path": "still.avif",
+        "sha256": "1f9b64b2a8394f321d5ae700ff6467a85eff78ea3d27903ace802a8a72d2f05a"
+      },
+      {
+        "path": "still.gif",
+        "sha256": "dfa67b43ec5bb7fd286215b9044f9850a03a0087c792d6eb22f1f772a7cea1cf"
+      },
+      {
+        "path": "still.heic",
+        "sha256": "d871555404472e2e575fa70e6630388e4eaaea3017f31e8059442a1316d74f2f"
+      },
+      {
+        "path": "still.jpg",
+        "sha256": "56a3896ef22c6539399233213d003334b6edf2433b08d52608b752dfb3c5a20b"
+      },
+      {
+        "path": "still.png",
+        "sha256": "f76c90db1b6ad91a5ba79aef6e9f031c42348e016fa1f274a1b4a5ea5e723fd0"
+      },
+      {
+        "path": "still.tif",
+        "sha256": "c242d26c8b778ad3393d302612348d9daa3570c90560ac7752e9346b0799d605"
+      },
+      {
+        "path": "still.webp",
+        "sha256": "7c8bacf7409195d53fcc050b94d5a42b9e8a97a306693f5129c9a17e5fc205a4"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Adds image and video benchmarks covering common operations reporting time, CPU usage, RSS diff and RSS max. Each benchmark runs in a separate subprocess to isolate CPU and memory measurements.
