### PR TITLE
Add outOfRangeLast opt to extractFrames

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,9 +185,10 @@ Check with `isStripMetadataSupported()` for supported types, only `jpeg` at the 
 
 Extracts frames from a video in RGBA
 
-| Parameter         | Type   | Description                    |
-| ----------------- | ------ | ------------------------------ |
-| `opts.frameIndex` | number | Number of the frame to extract |
+| Parameter             | Type    | Description                                                                      |
+| --------------------- | ------- | -------------------------------------------------------------------------------- |
+| `opts.frameIndex`     | number  | Number of the frame to extract                                                   |
+| `opts.outOfRangeLast` | boolean | Fall back to the last frame when `frameIndex` is beyond the end. Default `false` |
 
 ### metadata()
 

--- a/src/video.js
+++ b/src/video.js
@@ -7,19 +7,6 @@ async function extractFrames(fd, opts = {}) {
   const { frameIndex, outOfRangeLast = false } = opts
 
   const ffmpeg = await importFFmpeg()
-
-  const first = decodeFrameAt(fd, ffmpeg, frameIndex)
-  if (first.result) return first.result
-
-  if (outOfRangeLast && first.currentFrame > 0 && frameIndex >= first.currentFrame) {
-    const second = decodeFrameAt(fd, ffmpeg, first.currentFrame - 1)
-    if (second.result) return second.result
-  }
-
-  throw new Error(`Frame ${frameIndex} not found (video only has ${first.currentFrame} frames)`)
-}
-
-function decodeFrameAt(fd, ffmpeg, frameIndex) {
   const io = createIOContext(fd, ffmpeg)
 
   using inputFormat = new ffmpeg.InputFormatContext(io)
@@ -28,8 +15,15 @@ function decodeFrameAt(fd, ffmpeg, frameIndex) {
   decoder.open()
 
   using packet = new ffmpeg.Packet()
-  using frame = new ffmpeg.Frame()
 
+  // receiveFrame unrefs the frame it is given before writing into it, so
+  // alternate between two frames to keep the previous one intact for the
+  // outOfRangeLast fallback
+  using frameA = new ffmpeg.Frame()
+  using frameB = new ffmpeg.Frame()
+
+  let frame = frameA
+  let lastFrame = null
   let currentFrame = 0
   let result = null
 
@@ -38,38 +32,11 @@ function decodeFrameAt(fd, ffmpeg, frameIndex) {
       if (decoder.sendPacket(packet)) {
         while (decoder.receiveFrame(frame)) {
           if (currentFrame === frameIndex) {
-            // Convert to RGBA
-            using scaler = new ffmpeg.Scaler(
-              frame.format,
-              frame.width,
-              frame.height,
-              ffmpeg.constants.pixelFormats.RGBA,
-              frame.width,
-              frame.height
-            )
-
-            using rgbaFrame = new ffmpeg.Frame()
-            rgbaFrame.width = frame.width
-            rgbaFrame.height = frame.height
-            rgbaFrame.format = ffmpeg.constants.pixelFormats.RGBA
-            rgbaFrame.alloc()
-
-            scaler.scale(frame, rgbaFrame)
-
-            const image = new ffmpeg.Image(
-              ffmpeg.constants.pixelFormats.RGBA,
-              rgbaFrame.width,
-              rgbaFrame.height
-            )
-            image.read(rgbaFrame)
-
-            result = {
-              width: rgbaFrame.width,
-              height: rgbaFrame.height,
-              data: image.data
-            }
+            result = convertToRGBA(ffmpeg, frame)
             break
           }
+          lastFrame = frame
+          frame = frame === frameA ? frameB : frameA
           currentFrame++
         }
       }
@@ -78,7 +45,47 @@ function decodeFrameAt(fd, ffmpeg, frameIndex) {
     if (result) break
   }
 
-  return { result, currentFrame }
+  if (!result && outOfRangeLast && lastFrame && frameIndex >= currentFrame) {
+    result = convertToRGBA(ffmpeg, lastFrame)
+  }
+
+  if (!result) {
+    throw new Error(`Frame ${frameIndex} not found (video only has ${currentFrame} frames)`)
+  }
+
+  return result
+}
+
+function convertToRGBA(ffmpeg, frame) {
+  using scaler = new ffmpeg.Scaler(
+    frame.format,
+    frame.width,
+    frame.height,
+    ffmpeg.constants.pixelFormats.RGBA,
+    frame.width,
+    frame.height
+  )
+
+  using rgbaFrame = new ffmpeg.Frame()
+  rgbaFrame.width = frame.width
+  rgbaFrame.height = frame.height
+  rgbaFrame.format = ffmpeg.constants.pixelFormats.RGBA
+  rgbaFrame.alloc()
+
+  scaler.scale(frame, rgbaFrame)
+
+  const image = new ffmpeg.Image(
+    ffmpeg.constants.pixelFormats.RGBA,
+    rgbaFrame.width,
+    rgbaFrame.height
+  )
+  image.read(rgbaFrame)
+
+  return {
+    width: rgbaFrame.width,
+    height: rgbaFrame.height,
+    data: image.data
+  }
 }
 
 async function* transcode(fd, opts = {}) {

--- a/src/video.js
+++ b/src/video.js
@@ -66,6 +66,9 @@ async function extractFrames(fd, opts = {}) {
   }
 
   if (!result) {
+    if (currentFrame > 0 && frameIndex >= currentFrame) {
+      return extractFrames(fd, { ...opts, frameIndex: currentFrame - 1 })
+    }
     throw new Error(`Frame ${frameIndex} not found (video only has ${currentFrame} frames)`)
   }
 

--- a/src/video.js
+++ b/src/video.js
@@ -4,9 +4,22 @@ import { createIOContext } from './video/io'
 import { metadata } from './video/metadata'
 
 async function extractFrames(fd, opts = {}) {
-  const { frameIndex } = opts
+  const { frameIndex, outOfRangeLast = false } = opts
 
   const ffmpeg = await importFFmpeg()
+
+  const first = decodeFrameAt(fd, ffmpeg, frameIndex)
+  if (first.result) return first.result
+
+  if (outOfRangeLast && first.currentFrame > 0 && frameIndex >= first.currentFrame) {
+    const second = decodeFrameAt(fd, ffmpeg, first.currentFrame - 1)
+    if (second.result) return second.result
+  }
+
+  throw new Error(`Frame ${frameIndex} not found (video only has ${first.currentFrame} frames)`)
+}
+
+function decodeFrameAt(fd, ffmpeg, frameIndex) {
   const io = createIOContext(fd, ffmpeg)
 
   using inputFormat = new ffmpeg.InputFormatContext(io)
@@ -65,14 +78,7 @@ async function extractFrames(fd, opts = {}) {
     if (result) break
   }
 
-  if (!result) {
-    if (currentFrame > 0 && frameIndex >= currentFrame) {
-      return extractFrames(fd, { ...opts, frameIndex: currentFrame - 1 })
-    }
-    throw new Error(`Frame ${frameIndex} not found (video only has ${currentFrame} frames)`)
-  }
-
-  return result
+  return { result, currentFrame }
 }
 
 async function* transcode(fd, opts = {}) {

--- a/src/video.js
+++ b/src/video.js
@@ -45,6 +45,20 @@ async function extractFrames(fd, opts = {}) {
     if (result) break
   }
 
+  if (!result) {
+    using flushPacket = new ffmpeg.Packet()
+    decoder.sendPacket(flushPacket)
+    while (decoder.receiveFrame(frame)) {
+      if (currentFrame === frameIndex) {
+        result = convertToRGBA(ffmpeg, frame)
+        break
+      }
+      lastFrame = frame
+      frame = frame === frameA ? frameB : frameA
+      currentFrame++
+    }
+  }
+
   if (!result && outOfRangeLast && lastFrame && frameIndex >= currentFrame) {
     result = convertToRGBA(ffmpeg, lastFrame)
   }

--- a/src/video.js
+++ b/src/video.js
@@ -24,20 +24,20 @@ async function extractFrames(fd, opts = {}) {
 
   let frame = frameA
   let lastFrame = null
-  let currentFrame = 0
+  let currentFrameIndex = 0
   let result = null
 
   while (inputFormat.readFrame(packet)) {
     if (packet.streamIndex === stream.index) {
       if (decoder.sendPacket(packet)) {
         while (decoder.receiveFrame(frame)) {
-          if (currentFrame === frameIndex) {
+          if (currentFrameIndex === frameIndex) {
             result = convertToRGBA(ffmpeg, frame)
             break
           }
           lastFrame = frame
           frame = frame === frameA ? frameB : frameA
-          currentFrame++
+          currentFrameIndex++
         }
       }
     }
@@ -49,22 +49,22 @@ async function extractFrames(fd, opts = {}) {
     using flushPacket = new ffmpeg.Packet()
     decoder.sendPacket(flushPacket)
     while (decoder.receiveFrame(frame)) {
-      if (currentFrame === frameIndex) {
+      if (currentFrameIndex === frameIndex) {
         result = convertToRGBA(ffmpeg, frame)
         break
       }
       lastFrame = frame
       frame = frame === frameA ? frameB : frameA
-      currentFrame++
+      currentFrameIndex++
     }
   }
 
-  if (!result && outOfRangeLast && lastFrame && frameIndex >= currentFrame) {
+  if (!result && outOfRangeLast && lastFrame && frameIndex >= currentFrameIndex) {
     result = convertToRGBA(ffmpeg, lastFrame)
   }
 
   if (!result) {
-    throw new Error(`Frame ${frameIndex} not found (video only has ${currentFrame} frames)`)
+    throw new Error(`Frame ${frameIndex} not found (video only has ${currentFrameIndex} frames)`)
   }
 
   return result

--- a/src/video.js
+++ b/src/video.js
@@ -19,8 +19,8 @@ async function extractFrames(fd, opts = {}) {
   // receiveFrame unrefs the frame it is given before writing into it, so
   // alternate between two frames to keep the previous one intact for the
   // outOfRangeLast fallback
-  using frameA = new ffmpeg.Frame()
-  using frameB = new ffmpeg.Frame()
+  using frame = new ffmpeg.Frame()
+  using prevFrame = new ffmpeg.Frame()
 
   let frame = frameA
   let lastFrame = null

--- a/test/video.js
+++ b/test/video.js
@@ -32,11 +32,22 @@ test('video extractFrames() in pipeline', async (t) => {
   t.is(rgba.height, 240)
 })
 
-test('video extractFrames() falls back to the last frame when frameIndex is beyond the end', async (t) => {
+test('video extractFrames() throws when frameIndex is beyond the end', async (t) => {
+  const path = './test/fixtures/sample.mp4'
+
+  await t.exception(async () => {
+    await video(path).extractFrames({ frameIndex: 999999 })
+  }, /Frame 999999 not found/)
+})
+
+test('video extractFrames() with outOfRangeLast falls back to the last frame', async (t) => {
   const path = './test/fixtures/sample.mp4'
 
   const lastFrame = await video(path).extractFrames({ frameIndex: 97 })
-  const rgba = await video(path).extractFrames({ frameIndex: 999999 })
+  const rgba = await video(path).extractFrames({
+    frameIndex: 999999,
+    outOfRangeLast: true
+  })
 
   t.is(rgba.width, 320)
   t.is(rgba.height, 240)

--- a/test/video.js
+++ b/test/video.js
@@ -32,6 +32,17 @@ test('video extractFrames() in pipeline', async (t) => {
   t.is(rgba.height, 240)
 })
 
+test('video extractFrames() falls back to the last frame when frameIndex is beyond the end', async (t) => {
+  const path = './test/fixtures/sample.mp4'
+
+  const lastFrame = await video(path).extractFrames({ frameIndex: 97 })
+  const rgba = await video(path).extractFrames({ frameIndex: 999999 })
+
+  t.is(rgba.width, 320)
+  t.is(rgba.height, 240)
+  t.ok(b4a.equals(rgba.data, lastFrame.data))
+})
+
 test('video metadata()', async (t) => {
   const path = './test/fixtures/orientation.mov'
 

--- a/test/video.js
+++ b/test/video.js
@@ -43,7 +43,7 @@ test('video extractFrames() throws when frameIndex is beyond the end', async (t)
 test('video extractFrames() with outOfRangeLast falls back to the last frame', async (t) => {
   const path = './test/fixtures/sample.mp4'
 
-  const lastFrame = await video(path).extractFrames({ frameIndex: 97 })
+  const lastFrame = await video(path).extractFrames({ frameIndex: 99 })
   const rgba = await video(path).extractFrames({
     frameIndex: 999999,
     outOfRangeLast: true

--- a/test/video.js
+++ b/test/video.js
@@ -47,6 +47,8 @@ test('video extractFrames() with outOfRangeLast falls back to the last frame', a
   const rgba = await video(path).extractFrames({
     frameIndex: 999999,
     outOfRangeLast: true
+  const rgba = await video(path).extractFrames({
+    frameIndex: 'last',
   })
 
   t.is(rgba.width, 320)


### PR DESCRIPTION
extractFrames keeps strict indexing by default: requesting a frame beyond the end of the video throws. With outOfRangeLast: true it returns the last decoded frame instead.