### PR TITLE
Clean up binary metadata in CLI output

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -11,6 +11,7 @@ import {
 } from 'bare-media/types'
 import getMimeType from 'get-mime-type'
 
+import { cleanMetadata } from './lib/bin'
 import { detectMimeType } from './src/codecs'
 import pkg from './package'
 
@@ -192,30 +193,6 @@ function validateFlag(value, name, type) {
   if (type === 'number' && value !== undefined) {
     return Number.parseInt(value)
   }
-  return value
-}
-
-function cleanMetadata(value) {
-  if (Buffer.isBuffer(value)) {
-    const byteLength = value.byteLength
-    const text = value.toString()
-    const printable = !/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/.test(text)
-
-    return byteLength > 0 && printable && Buffer.from(text).equals(value)
-      ? text
-      : `<binary data: ${byteLength} ${byteLength === 1 ? 'byte' : 'bytes'}>`
-  }
-
-  if (Array.isArray(value)) return value.map(cleanMetadata)
-
-  if (value && typeof value === 'object') {
-    const data = {}
-    for (const [key, entry] of Object.entries(value)) {
-      data[key] = cleanMetadata(entry)
-    }
-    return data
-  }
-
   return value
 }
 

--- a/bin.js
+++ b/bin.js
@@ -30,6 +30,7 @@ const cli = command(
     arg('[output]', 'Output media file'),
     flag('--strip', 'Strip image metadata'),
     flag('--json|-j', 'Print JSON'),
+    flag('--raw|-r', 'Show binary metadata values'),
     metadata
   ),
   command(
@@ -82,15 +83,16 @@ async function metadata(parsed) {
       return
     }
 
-    const data = await image(input).metadata()
-    const out = data || { mimetype }
-    print(out, { json: parsed.flags.json })
+    const data = (await image(input).metadata()) || { mimetype }
+    const output = parsed.flags.raw ? data : cleanMetadata(data)
+    print(output, { json: parsed.flags.json })
     return
   }
 
   if (mimetype.startsWith('video/')) {
     const data = await video(input).metadata()
-    print(data, { json: parsed.flags.json })
+    const output = parsed.flags.raw ? data : cleanMetadata(data)
+    print(output, { json: parsed.flags.json })
     return
   }
 
@@ -190,6 +192,30 @@ function validateFlag(value, name, type) {
   if (type === 'number' && value !== undefined) {
     return Number.parseInt(value)
   }
+  return value
+}
+
+function cleanMetadata(value) {
+  if (Buffer.isBuffer(value)) {
+    const byteLength = value.byteLength
+    const text = value.toString()
+    const printable = !/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/.test(text)
+
+    return byteLength > 0 && printable && Buffer.from(text).equals(value)
+      ? text
+      : `<binary data: ${byteLength} ${byteLength === 1 ? 'byte' : 'bytes'}>`
+  }
+
+  if (Array.isArray(value)) return value.map(cleanMetadata)
+
+  if (value && typeof value === 'object') {
+    const data = {}
+    for (const [key, entry] of Object.entries(value)) {
+      data[key] = cleanMetadata(entry)
+    }
+    return data
+  }
+
   return value
 }
 

--- a/lib/bin.js
+++ b/lib/bin.js
@@ -1,0 +1,25 @@
+function cleanMetadata(value) {
+  if (Buffer.isBuffer(value)) {
+    const byteLength = value.byteLength
+    const text = value.toString()
+    const printable = !/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/.test(text)
+
+    return byteLength > 0 && printable && Buffer.from(text).equals(value)
+      ? text
+      : `<binary data: ${byteLength} ${byteLength === 1 ? 'byte' : 'bytes'}>`
+  }
+
+  if (Array.isArray(value)) return value.map(cleanMetadata)
+
+  if (value && typeof value === 'object') {
+    const data = {}
+    for (const [key, entry] of Object.entries(value)) {
+      data[key] = cleanMetadata(entry)
+    }
+    return data
+  }
+
+  return value
+}
+
+export { cleanMetadata }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "./types": "./types.js"
   },
   "files": [
+    "lib",
     "src",
     "index.js",
     "types.js"

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 import('./test/image')
 import('./test/video')
 import('./test/common')
+import('./test/bin')
 import('./test/samples/image')
 import('./test/samples/video')

--- a/test/bin.js
+++ b/test/bin.js
@@ -1,0 +1,28 @@
+import { test } from 'brittle'
+
+import { cleanMetadata } from '../lib/bin'
+
+test('cleanMetadata() summarizes binary buffers', (t) => {
+  t.is(cleanMetadata(Buffer.alloc(0)), '<binary data: 0 bytes>')
+  t.is(cleanMetadata(Buffer.from([0x00])), '<binary data: 1 byte>')
+  t.is(cleanMetadata(Buffer.from([0xff, 0x00])), '<binary data: 2 bytes>')
+})
+
+test('cleanMetadata() keeps readable buffers', (t) => {
+  t.is(cleanMetadata(Buffer.from('0210')), '0210')
+  t.is(cleanMetadata(Buffer.from('CameraBrand')), 'CameraBrand')
+})
+
+test('cleanMetadata() recursively cleans metadata', (t) => {
+  const input = {
+    version: Buffer.from('0210'),
+    items: [{ data: Buffer.from([0xff]) }]
+  }
+
+  const clean = cleanMetadata(input)
+
+  t.alike(clean, {
+    version: '0210',
+    items: [{ data: '<binary data: 1 byte>' }]
+  })
+})


### PR DESCRIPTION
When requesting metadata in the CLI, the binary data is now hidden:
```
...
MAKER_NOTE: <binary data: 6940 bytes>
...
```

This also adds a `--raw` flag to display the binary values